### PR TITLE
updates Ops Agent config during init to configure Sui metrics monitoring

### DIFF
--- a/terraform/full-node/README.md
+++ b/terraform/full-node/README.md
@@ -23,7 +23,7 @@ The Terraform script configures the following:
   - Service Management: Read Only
   - Stackdriver APIs: Various access levels
   - Storage: Read Write
-- **Ops Agent**: Ops Agent, Monitoring, and Logging installed
+- **Ops Agent**: Ops Agent, Monitoring, and Logging installed (Config updated to pipe Sui metrics to Ops Agent)
 
 The Cloud-init script provisions the `sui` user, installs necessary software packages, and prepares the environment for running a Sui Full Node.
 

--- a/terraform/full-node/cloud-init.yaml
+++ b/terraform/full-node/cloud-init.yaml
@@ -27,6 +27,28 @@ runcmd:
   - echo 'Installing Google Cloud Ops Agent...'
   - curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
   - sudo bash add-google-cloud-ops-agent-repo.sh --also-install
+
+  # Configure Ops Agent to pipe Sui metrics into Cloud Monitoring
+  - |
+    sudo bash -c 'cat << EOF > /etc/google-cloud-ops-agent/config.yaml
+    metrics:
+      receivers:
+        prometheus:
+          type: prometheus
+          config:
+            scrape_configs:
+              - job_name: 'sui-metrics'
+                static_configs:
+                  - targets: ['localhost:9184']
+                scrape_interval: 30s
+      service:
+        pipelines:
+          default_pipeline:
+            receivers: [prometheus]
+    EOF'
+
+  # Restart Ops Agent to apply changes
+  - sudo service google-cloud-ops-agent restart
   - echo "Ops Agent installation complete."
   - mkdir -p /opt/sui/bin
   - mkdir -p /opt/sui/config


### PR DESCRIPTION
# Description

- updates `config.yaml` for GCP Ops Agent to use a Prometheus receiver and scrape on `localhost:9184/metrics` (default Sui metrics endpoint)

This enables Ops Agent to identify and send over Sui Metrics to GCP

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Configured on an existing Sui full node instance and validated in GCP Monitoring
Then used `terraform apply` on a new Sui full node with Ops Agent config updates to verify again that it piped metrics as expected

<img width="1727" alt="Screenshot 2024-02-05 at 11 47 31 AM" src="https://github.com/SZNS/sui-node/assets/105989817/2c7aadc9-56c9-4c7f-ae5d-e808333f2bab">


