### PR TITLE
Adding in script for auto updating sui node version when theres a new…

### DIFF
--- a/terraform/full-node/main.tf
+++ b/terraform/full-node/main.tf
@@ -156,4 +156,27 @@ data "cloudinit_config" "cloud_init" {
                     sudo systemctl start sui-node
                     EOF
   }
+  part {
+    filename     = "update_sui_node.sh"
+    content_type = "text/x-shellscript"
+    content      = file("${path.module}/scripts/update_sui_node.sh")
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+    content      = <<-EOF
+                    #!/bin/sh
+                    mkdir -p /opt/scripts
+                    mv /var/lib/cloud/instance/scripts/update_sui_node.sh /opt/scripts/update_sui_node.sh
+                    chmod +x /opt/scripts/update_sui_node.sh
+                    EOF
+  }
+  part {
+    content_type = "text/x-shellscript"
+    content      = <<-EOF
+                    #!/bin/sh
+                    # Add a cron job to run the update script daily at 2:00 AM
+                    (crontab -l 2>/dev/null; echo "0 2 * * * /opt/scripts/update_sui_node.sh") | crontab -
+                    EOF
+  }
 }

--- a/terraform/full-node/scripts/update_sui_node.sh
+++ b/terraform/full-node/scripts/update_sui_node.sh
@@ -5,10 +5,10 @@ SCRIPT_DIR="/opt/sui"
 CURRENT_VERSION_FILE="$SCRIPT_DIR/current_version.txt"
 INSTALL_PATH="/opt/sui/bin"
 
-# Ensure jq is installed
+# Install jq if its not installed
 if ! command -v jq &> /dev/null; then
   echo "jq could not be found, attempting to install..."
-  sudo apt-get update && sudo apt-get install -y jq
+  apt-get update && apt-get install -y jq
 fi
 
 echo "Fetching the latest 5 releases information"
@@ -48,35 +48,24 @@ fi
 
 # Compare the current version with the latest commit SHA
 if [ "$ACTUAL_COMMIT_SHA" != "$CURRENT_VERSION" ]; then
-    echo "A new mainnet release was found. Updating to $ACTUAL_COMMIT_SHA..."
+    echo "A new mainnet release was found: $LATEST_MAINNET_TAG ($LATEST_COMMIT_SHA). Updating..."
 
     echo "Removing the old binary..."
-    sudo rm -f $INSTALL_PATH/sui-node
+    rm -f $INSTALL_PATH/sui-node
 
     echo "Downloading the latest Sui Node binary"
     wget -P $INSTALL_PATH "https://releases.sui.io/${ACTUAL_COMMIT_SHA}/sui-node"
 
     echo "Setting permissions on the new binary"
-    sudo chown -R sui:sui $INSTALL_PATH
-    sudo chmod 544 $INSTALL_PATH/sui-node
+    chown -R sui:sui $INSTALL_PATH
+    chmod 544 $INSTALL_PATH/sui-node
 
     echo $ACTUAL_COMMIT_SHA > $CURRENT_VERSION_FILE
 
     echo "Stopping the Sui Full Node service"
-    sudo systemctl stop sui-node
+    systemctl stop sui-node
     echo "Restarting the Sui Full Node service"
-    sudo systemctl start sui-node
-
-    echo "Restart analytics indexer"
-    sudo systemctl daemon-reload
-    # Do this for every relevant analytics service running
-    sudo systemctl restart sui-analytics-type-checkpoint
-    sudo systemctl restart sui-analytics-type-event
-    sudo systemctl restart sui-analytics-type-move-call
-    sudo systemctl restart sui-analytics-type-move-package
-    sudo systemctl restart sui-analytics-type-object
-    sudo systemctl restart sui-analytics-type-transaction
-    sudo systemctl restart sui-analytics-type-transaction-objects
+    systemctl start sui-node
 
     echo "Update completed successfully."
 else

--- a/terraform/full-node/scripts/update_sui_node.sh
+++ b/terraform/full-node/scripts/update_sui_node.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Configuration
+SCRIPT_DIR="/opt/sui"
+CURRENT_VERSION_FILE="$SCRIPT_DIR/current_version.txt"
+INSTALL_PATH="/opt/sui/bin"
+
+# Ensure jq is installed
+if ! command -v jq &> /dev/null; then
+  echo "jq could not be found, attempting to install..."
+  sudo apt-get update && sudo apt-get install -y jq
+fi
+
+echo "Fetching the latest 5 releases information"
+RELEASES_DATA=$(curl -s "https://api.github.com/repos/MystenLabs/sui/releases?per_page=5")
+
+# Parse the latest mainnet release tag using jq
+LATEST_MAINNET_TAG=$(echo "$RELEASES_DATA" | jq -r '.[] | select(.tag_name | test("mainnet")) | .tag_name' | head -1)
+
+if [ -z "$LATEST_MAINNET_TAG" ]; then
+    echo "No mainnet release found. Exiting."
+    exit 1
+fi
+
+echo "Latest mainnet tag is $LATEST_MAINNET_TAG"
+
+# Fetch tag details to get the commit SHA. This doesn't contain the commit SHA that we need to install the right version.
+TAG_DETAILS=$(curl -s "https://api.github.com/repos/MystenLabs/sui/git/refs/tags/$LATEST_MAINNET_TAG")
+COMMIT_URL=$(echo "$TAG_DETAILS" | jq -r '.object.url')
+
+# Fetch the actual commit SHA from the commit URL
+COMMIT_DETAILS=$(curl -s "$COMMIT_URL")
+ACTUAL_COMMIT_SHA=$(echo "$COMMIT_DETAILS" | jq -r '.object.sha')
+
+if [ -z "$ACTUAL_COMMIT_SHA" ]; then
+    echo "Failed to fetch the actual commit SHA. Exiting."
+    exit 1
+fi
+
+echo "Latest commit SHA for mainnet is $ACTUAL_COMMIT_SHA"
+
+# Read the current version from file
+if [ -f "$CURRENT_VERSION_FILE" ]; then
+    CURRENT_VERSION=$(cat $CURRENT_VERSION_FILE)
+else
+    CURRENT_VERSION=""
+fi
+
+# Compare the current version with the latest commit SHA
+if [ "$ACTUAL_COMMIT_SHA" != "$CURRENT_VERSION" ]; then
+    echo "A new mainnet release was found. Updating to $ACTUAL_COMMIT_SHA..."
+
+    echo "Removing the old binary..."
+    sudo rm -f $INSTALL_PATH/sui-node
+
+    echo "Downloading the latest Sui Node binary"
+    wget -P $INSTALL_PATH "https://releases.sui.io/${ACTUAL_COMMIT_SHA}/sui-node"
+
+    echo "Setting permissions on the new binary"
+    sudo chown -R sui:sui $INSTALL_PATH
+    sudo chmod 544 $INSTALL_PATH/sui-node
+
+    echo $ACTUAL_COMMIT_SHA > $CURRENT_VERSION_FILE
+
+    echo "Stopping the Sui Full Node service"
+    sudo systemctl stop sui-node
+    echo "Restarting the Sui Full Node service"
+    sudo systemctl start sui-node
+
+    echo "Restart analytics indexer"
+    sudo systemctl daemon-reload
+    # Do this for every relevant analytics service running
+    sudo systemctl restart sui-analytics-type-checkpoint
+    sudo systemctl restart sui-analytics-type-event
+    sudo systemctl restart sui-analytics-type-move-call
+    sudo systemctl restart sui-analytics-type-move-package
+    sudo systemctl restart sui-analytics-type-object
+    sudo systemctl restart sui-analytics-type-transaction
+    sudo systemctl restart sui-analytics-type-transaction-objects
+
+    echo "Update completed successfully."
+else
+    echo "No update is needed. Current version $CURRENT_VERSION is up to date."
+fi
+

--- a/terraform/full-node/variables.tf
+++ b/terraform/full-node/variables.tf
@@ -26,5 +26,5 @@ variable "service_account_email" {
 
 variable "sui_release_commit_sha" {
   description = "Latest Commit SHA for the Sui Node"
-  default     = "115117180263c8bc25190ce76b6cbe2114551f7c"
+  default     = "09db80adf1af7f60464ffc04b09b8fafc02917c5"
 }


### PR DESCRIPTION
# Description

Whenever Sui releases a new version, we must update the full node with the release. Currently this process is manually done by sshing into the compute instance and restarting the sui full node and restarting the analytics indexer.

Linear Ticket: [(link to notion)](https://linear.app/szns-solutions/issue/SZN-181/automate-node-upgrades)

## Type of change

This PR adds a script that would automatically update the SUI version and restart the services. It also adds a cron job that triggers the script which periodically polls the github releases and check for mainnet updates.

# How Has This Been Tested?

This was tested in the sui-node-test gcp account. I was able to run terraform apply and run the sui node in the test account and also checked that the new script and cron were successfully created

