### PR TITLE
add slack webhoook integration for notifications

### DIFF
--- a/terraform/full-node/README.md
+++ b/terraform/full-node/README.md
@@ -76,5 +76,11 @@ If `service_account_email` is not provided, the default service account will be 
    service_account_email = "your-service-account-email@example.com"
    ```
 
+If `SLACK_SECRET_NAME` variable is set in variables.tf or terraform.tfvars file, the system will attempt to fetch the webhook URL from Secret Manager and send notifications to the specified Slack channel.
+
+   ```
+   SLACK_SECRET_NAME = "your-service-account-email@example.com"
+   ```
+
 4. **Deploy**: Execute `terraform apply` to create the resources in GCP.
 5. **Teardown**: Use `terraform destroy` to remove the infrastructure when needed.

--- a/terraform/full-node/main.tf
+++ b/terraform/full-node/main.tf
@@ -79,7 +79,8 @@ resource "google_compute_instance" "vm_instance" {
       "https://www.googleapis.com/auth/logging.write",
       "https://www.googleapis.com/auth/monitoring.write",
       "https://www.googleapis.com/auth/trace.append",
-      "https://www.googleapis.com/auth/devstorage.read_write"
+      "https://www.googleapis.com/auth/devstorage.read_write",
+      "https://www.googleapis.com/auth/cloud-platform"
     ]
   }
 

--- a/terraform/full-node/main.tf
+++ b/terraform/full-node/main.tf
@@ -163,6 +163,16 @@ data "cloudinit_config" "cloud_init" {
     content      = file("${path.module}/scripts/update_sui_node.sh")
   }
 
+  # Initialize the current_version.txt file
+  part {
+    content_type = "text/x-shellscript"
+    content      = <<-EOF
+                    #!/bin/sh
+                    # Initialize the current_version.txt file with the given Sui release commit SHA
+                    echo "${var.sui_release_commit_sha}" > /opt/sui/current_version.txt
+                    EOF
+  }
+
   part {
     content_type = "text/x-shellscript"
     content      = <<-EOF
@@ -177,7 +187,7 @@ data "cloudinit_config" "cloud_init" {
     content      = <<-EOF
                     #!/bin/sh
                     # Add a cron job to run the update script daily at 2:00 AM
-                    (crontab -l 2>/dev/null; echo "0 2 * * * /opt/scripts/update_sui_node.sh") | crontab -
+                    (crontab -l 2>/dev/null; echo "0 2 * * * /opt/scripts/update_sui_node.sh ${var.SLACK_SECRET_NAME}") | crontab -
                     EOF
   }
 }

--- a/terraform/full-node/scripts/update_sui_node.sh
+++ b/terraform/full-node/scripts/update_sui_node.sh
@@ -4,6 +4,7 @@
 SCRIPT_DIR="/opt/sui"
 CURRENT_VERSION_FILE="$SCRIPT_DIR/current_version.txt"
 INSTALL_PATH="/opt/sui/bin"
+SLACK_SECRET_NAME=$1
 
 # Install jq if its not installed
 if ! command -v jq &> /dev/null; then
@@ -48,7 +49,7 @@ fi
 
 send_slack_message() {
   local SLACK_MESSAGE=$1
-  SLACK_WEBHOOK_URL=$(gcloud secrets versions access latest --secret="slack-webhook-url" 2>/dev/null)
+  SLACK_WEBHOOK_URL=$(gcloud secrets versions access latest --secret="${SLACK_SECRET_NAME}" 2>/dev/null)
   if [ -n "$SLACK_WEBHOOK_URL" ]; then
     curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"${SLACK_MESSAGE}\"}" "${SLACK_WEBHOOK_URL}"
   else
@@ -77,8 +78,12 @@ if [ "$ACTUAL_COMMIT_SHA" != "$CURRENT_VERSION" ]; then
     systemctl start sui-node
 
     echo "Update completed successfully."
-    send_slack_message "SUI Node updated successfully to version $LATEST_MAINNET_TAG ($ACTUAL_COMMIT_SHA)."
+
+    if [ -n "$SLACK_SECRET_NAME" ]; then
+      SLACK_MESSAGE="SUI Node updated successfully to version $LATEST_MAINNET_TAG ($ACTUAL_COMMIT_SHA)."
+      send_slack_message "$SLACK_MESSAGE"
+    fi
+    
 else
     echo "No update is needed. Current version $CURRENT_VERSION is up to date."
 fi
-

--- a/terraform/full-node/variables.tf
+++ b/terraform/full-node/variables.tf
@@ -28,3 +28,9 @@ variable "sui_release_commit_sha" {
   description = "Latest Commit SHA for the Sui Node"
   default     = "09db80adf1af7f60464ffc04b09b8fafc02917c5"
 }
+
+variable "SLACK_SECRET_NAME" {
+  description = "The name of the Slack webhook url in GCP Secret Manager"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
# Description

Whenever the script for SUI update runs we want to notify our team via slack. This PR adds slack notification to the webhook url specified in our secret manager.
Linear Ticket: [(link to notion)](https://linear.app/szns-solutions/issue/SZN-181/automate-node-upgrades)

## Type of change

This PR adds a new feature which would send a slack notification to the webhook url specified in our secret manager

# How Has This Been Tested?

This PR has been tested in our test environment. The script ran successfully and sent a message to our slack channel.
