### PR TITLE
Sui node auto update

### DIFF
--- a/terraform/full-node/README.md
+++ b/terraform/full-node/README.md
@@ -79,7 +79,7 @@ If `service_account_email` is not provided, the default service account will be 
 If `SLACK_SECRET_NAME` variable is set in variables.tf or terraform.tfvars file, the system will attempt to fetch the webhook URL from Secret Manager and send notifications to the specified Slack channel.
 
    ```
-   SLACK_SECRET_NAME = "your-service-account-email@example.com"
+   SLACK_SECRET_NAME = "slack-webhook-url"
    ```
 
 4. **Deploy**: Execute `terraform apply` to create the resources in GCP.

--- a/terraform/full-node/variables.tf
+++ b/terraform/full-node/variables.tf
@@ -32,5 +32,5 @@ variable "sui_release_commit_sha" {
 variable "SLACK_SECRET_NAME" {
   description = "The name of the Slack webhook url in GCP Secret Manager"
   type        = string
-  default     = ""
+  default     = "slack-webhook-url"
 }


### PR DESCRIPTION
This PR sets the SLACK_SECRET_NAME to "slack-webhook-url" as default value when deploying terraform