### PR TITLE
Fix/eng 104

### DIFF
--- a/docs/analytics-indexer.md
+++ b/docs/analytics-indexer.md
@@ -85,12 +85,12 @@ The Sui Analytics Indexer extracts, processes, and exports data from the Sui blo
     - task_name: "object"
       file_type: "Object"
       file_format: "CSV"
-      checkpoint_interval: 100
+      checkpoint_interval: 1000
 
     - task_name: "event"
       file_type: "Event"
       file_format: "CSV"
-      checkpoint_interval: 10000
+      checkpoint_interval: 1000
 
     - task_name: "move-call"
       file_type: "MoveCall"
@@ -123,8 +123,9 @@ The Sui Analytics Indexer extracts, processes, and exports data from the Sui blo
     [Service]
     User=sui
     WorkingDirectory=/opt/sui/
-    Environment=RUST_BACKTRACE=full
+    Environment=RUST_BACKTRACE=1
     Environment=RUST_LOG=info,sui_core=debug,narwhal=debug,narwhal-primary::helper=info,jsonrpsee=error
+    Environment=MAX_ANNOTATED_VALUE_SIZE=20000000
     ExecStart=/opt/sui/bin/sui-analytics-indexer /opt/sui/config/analytics.yaml
     Restart=on-failure
     StandardOutput=journal

--- a/docs/analytics-indexer.md
+++ b/docs/analytics-indexer.md
@@ -1,4 +1,3 @@
-
 The Sui Analytics Indexer extracts, processes, and exports data from the Sui blockchain into structured data that's optimized for querying.
 
 # Prerequisites
@@ -40,179 +39,178 @@ The Sui Analytics Indexer extracts, processes, and exports data from the Sui blo
     sudo mv target/release/sui-analytics-indexer /opt/sui/bin
     ```
         
-5. Give ownership to the `sui` user
+6. Give ownership to the `sui` user
     
     ```bash
-        sudo chown -R sui:sui /opt/sui
-        sudo chmod 544 /opt/sui/bin/sui-node
+    sudo chown -R sui:sui /opt/sui
+    sudo chmod 544 /opt/sui/bin/sui-analytics-indexer
     ```
-    
 
-# Create Services
+# Configure the Analytics Indexer
 
-There are seven services that respectively export data types for: checkpoints, event, object, move-call, move-package, transactions, and transaction-objects. The below should be run seven times to export all the data.
+1. Create a YAML configuration file
 
-The below is an example to export checkpoint data. Please refer to `analytics/service` for other data types.
-
-1. Create a file in `/etc/systemd/system/sui-analytics-type-checkpoint.service`
-    1. [STARTING_SEQUENCE] - Starting checkpoint to begin export of data
-    2. [BUCKET_NAME] - A GCS bucket to export data
-    
     ```bash
+    sudo mkdir -p /opt/sui/config
+    sudo nano /opt/sui/config/analytics.yaml
+    ```
+
+2. Paste the following, updating the bucket name and service account path as needed
+
+    ```yaml
+    rest_url: "http://localhost:9000"
+    checkpoint_root: "/opt/sui/db"
+    remote_store_config:
+    object-store: "GCS"
+    bucket: "sui-mainnet-analytics"
+    google-service-account: "/path/to/your/service-account.json"
+    remote_store_url: "https://checkpoints.mainnet.sui.io"
+    package_cache_path: "/opt/sui/db/package_cache"
+    tasks:
+    - task_name: "checkpoint"
+        file_type: "Checkpoint"
+        file_format: "CSV"
+        checkpoint_interval: 1000
+
+    - task_name: "transaction"
+        file_type: "Transaction"
+        file_format: "CSV"
+        checkpoint_interval: 1000
+
+    - task_name: "transaction-bcs"
+        file_type: "TransactionBCS"
+        file_format: "CSV"
+        checkpoint_interval: 1000
+
+    - task_name: "transaction-objects"
+        file_type: "TransactionObjects"
+        file_format: "CSV"
+        checkpoint_interval: 1000
+
+    - task_name: "object"
+        file_type: "Object"
+        file_format: "CSV"
+        checkpoint_interval: 100
+
+    - task_name: "event"
+        file_type: "Event"
+        file_format: "CSV"
+        checkpoint_interval: 10000
+
+    - task_name: "move-call"
+        file_type: "MoveCall"
+        file_format: "CSV"
+        checkpoint_interval: 1000
+
+    - task_name: "package"
+        file_type: "MovePackage"
+        file_format: "CSV"
+        checkpoint_interval: 1000
+
+    - task_name: "wrapped-object"
+        file_type: "WrappedObject"
+        file_format: "CSV"
+        checkpoint_interval: 1000
+
+    ```
+
+    > **Note:**You can omit the `google-service-account` field if the VM has default service account permissions for GCS access.
+
+# Create Service
+
+1. Create a file in `/etc/systemd/system/sui-analytics-indexer.service`
+
+    ```bash
+    sudo nano /etc/systemd/system/sui-analytics-indexer.service
+    ```
+
+2. Paste the following service definition:
+
+    ```ini
     [Unit]
-    Description=Sui Analytics Indexer (Checkpoint)
-    
+    Description=Sui Analytics Indexer
+
     [Service]
     User=sui
     WorkingDirectory=/opt/sui/
-    Environment=RUST_BACKTRACE=1
+    Environment=RUST_BACKTRACE=full
     Environment=RUST_LOG=info,sui_core=debug,narwhal=debug,narwhal-primary::helper=info,jsonrpsee=error
-    ExecStart=/opt/sui/bin/sui-analytics-indexer --rest-url http://localhost:9000 --starting-checkpoint-seq-num [STARTING_SEQUENCE] --bucket [BUCKET_NAME] --file-format csv --client-metric-port 8081 --file-type checkpoint gcs --checkpoint-interval 1000
-    Restart=no
-    
+    ExecStart=/opt/sui/bin/sui-analytics-indexer /opt/sui/config/analytics.yaml
+    Restart=on-failure
+    StandardOutput=journal
+    StandardError=journal
+
     [Install]
     WantedBy=multi-user.target
     ```
-    
-2. Reload systemd and start the service
-    
+
+3. Reload systemd and start the service
+
     ```bash
     sudo systemctl daemon-reload
-    sudo systemctl start sui-analytics-type-checkpoint
+    sudo systemctl start sui-analytics-indexer
     ```
-    
-3. To monitor the service run
-    
+
+4. To monitor the service run
+
     ```bash
-    sudo journalctl -u sui-analytics-type-checkpoint -fo cat
+    sudo journalctl -u sui-analytics-indexer -fo cat
     ```
-    
 
 # Updating the Analytics Indexer
 
-1. Stop the service(s)
-    
+1. Stop the service
+
     ```bash
-    # Do this for every relevant analytics service running
-    
-    sudo systemctl stop sui-analytics-type-checkpoint
-    sudo systemctl stop sui-analytics-type-event
-    sudo systemctl stop sui-analytics-type-move-call
-    sudo systemctl stop sui-analytics-type-move-package
-    sudo systemctl stop sui-analytics-type-object
-    sudo systemctl stop sui-analytics-type-transaction
-    sudo systemctl stop sui-analytics-type-transaction-objects
+    sudo systemctl stop sui-analytics-indexer
     ```
-    
+
 2. Download the [Sui repository](https://github.com/MystenLabs/sui/tree/main)
-    
+
     ```bash
     git clone https://github.com/MystenLabs/sui.git
     ```
-    
+
 3. Enter the Sui respository via `cd ./sui`
 4. Fetch and pull the latest code
-    
+
     ```bash
     git fetch && git pull
-    
+
     # OPTIONAL: checkout a specific branch or release tag
     git checkout [BRANCH/COMMIT/TAG]
     ```
-    
+
 5. Build the sui analytics indexer package. This may take a few minutes to complete
-    
+
     ```bash
     cargo build --release --bin sui-analytics-indexer
     ```
-    
+
 6. Move the `sui-analytics-indexer` binary
-    
+
     ```bash
     sudo rm /opt/sui/bin/sui-analytics-indexer
     sudo mv target/release/sui-analytics-indexer /opt/sui/bin
     ```
-    
-7. Update all analytics services with a new `starting-checkpoint-seq-num` . This prevents the indexer from starting from checkpoints already indexed.
 
-   **THIS STEP IS IMPORTANT TO PREVENT DUPLICATE OR EXTRANEOUS DATA EXPORTS**
+7. Update ownership to `sui` user
 
-    
-    For example, in the service below replace `[STARTING_SEQUENCE]` with the last checkpoint indexed.
-    
     ```bash
-    [Unit]
-    Description=Sui Analytics Indexer (Checkpoint)
-    
-    [Service]
-    User=sui
-    WorkingDirectory=/opt/sui/
-    Environment=RUST_BACKTRACE=1
-    Environment=RUST_LOG=info,sui_core=debug,narwhal=debug,narwhal-primary::helper=info,jsonrpsee=error
-    ExecStart=/opt/sui/bin/sui-analytics-indexer --rest-url http://localhost:9000 --starting-checkpoint-seq-num [STARTING_SEQUENCE] --bucket [BUCKET_NAME] --file-format csv --client-metric-port 8081 --file-type checkpoint gcs --checkpoint-interval 1000
-    Restart=no
-    
-    [Install]
-    WantedBy=multi-user.target
+    sudo chown -R sui:sui /opt/sui
+    sudo chmod 544 /opt/sui/bin/sui-analytics-indexer
     ```
-9. Update ownership to `sui` user
-    
-    ```bash
-        sudo chown -R sui:sui /opt/sui
-        sudo chmod 544 /opt/sui/bin/sui-node
-    ```    
-8. Start all the services again
-    
+
+8. Restart the service
+
     ```bash
     sudo systemctl daemon-reload
-    
-    # Do this for every relevant analytics service running
-    sudo systemctl start sui-analytics-type-checkpoint
-    sudo systemctl start sui-analytics-type-event
-    sudo systemctl start sui-analytics-type-move-call
-    sudo systemctl start sui-analytics-type-move-package
-    sudo systemctl start sui-analytics-type-object
-    sudo systemctl start sui-analytics-type-transaction
-    sudo systemctl start sui-analytics-type-transaction-objects
+    sudo systemctl start sui-analytics-indexer
     ```
-    
 
-# Restarting the analytics indexer
+# Restarting the Analytics Indexer
 
-If any time the an analytics service stops or needs to restart.
+If any time the analytics service stops or needs to restart:
 
-1. Update all analytics services with a new `starting-checkpoint-seq-num` . This prevents the indexer from starting from checkpoints already indexed. 
-    
-    
-    For example to restart the analytics export for checkpoint data replace `[STARTING_SEQUENCE]` with the last checkpoint indexed.
-    
-    ```bash
-    [Unit]
-    Description=Sui Analytics Indexer (Checkpoint)
-    
-    [Service]
-    User=sui
-    WorkingDirectory=/opt/sui/
-    Environment=RUST_BACKTRACE=1
-    Environment=RUST_LOG=info,sui_core=debug,narwhal=debug,narwhal-primary::helper=info,jsonrpsee=error
-    ExecStart=/opt/sui/bin/sui-analytics-indexer --rest-url http://localhost:9000 --starting-checkpoint-seq-num [STARTING_SEQUENCE] --bucket [BUCKET_NAME] --file-format csv --client-metric-port 8081 --file-type checkpoint gcs --checkpoint-interval 1000
-    Restart=no
-    
-    [Install]
-    WantedBy=multi-user.target
-    ```
-    
-2. Restart all the services
-    
-    ```bash
-    sudo systemctl daemon-reload
-    
-    # Do this for every relevant analytics service running
-    sudo systemctl restart sui-analytics-type-checkpoint
-    sudo systemctl restart sui-analytics-type-event
-    sudo systemctl restart sui-analytics-type-move-call
-    sudo systemctl restart sui-analytics-type-move-package
-    sudo systemctl restart sui-analytics-type-object
-    sudo systemctl restart sui-analytics-type-transaction
-    sudo systemctl restart sui-analytics-type-transaction-objects
-    ```
+```bash
+sudo systemctl restart sui-analytics-indexer

--- a/docs/analytics-indexer.md
+++ b/docs/analytics-indexer.md
@@ -61,56 +61,46 @@ The Sui Analytics Indexer extracts, processes, and exports data from the Sui blo
     rest_url: "http://localhost:9000"
     checkpoint_root: "/opt/sui/db"
     remote_store_config:
-    object-store: "GCS"
-    bucket: "sui-mainnet-analytics"
-    google-service-account: "/path/to/your/service-account.json"
-    remote_store_url: "https://storage.googleapis.com/mysten-mainnet-checkpoints"
+      object-store: "GCS"
+      bucket: "sui-mainnet-analytics"
+      google-service-account: "/path/to/your/service-account.json"
+    remote_store_url: "https://checkpoints.mainnet.sui.io"
     package_cache_path: "/opt/sui/db/package_cache"
     tasks:
     - task_name: "checkpoint"
-        file_type: "Checkpoint"
-        file_format: "CSV"
-        checkpoint_interval: 1000
+      file_type: "Checkpoint"
+      file_format: "CSV"
+      checkpoint_interval: 1000
 
     - task_name: "transaction"
-        file_type: "Transaction"
-        file_format: "CSV"
-        checkpoint_interval: 1000
-
-    - task_name: "transaction-bcs"
-        file_type: "TransactionBCS"
-        file_format: "CSV"
-        checkpoint_interval: 1000
+      file_type: "Transaction"
+      file_format: "CSV"
+      checkpoint_interval: 1000
 
     - task_name: "transaction-objects"
-        file_type: "TransactionObjects"
-        file_format: "CSV"
-        checkpoint_interval: 1000
+      file_type: "TransactionObjects"
+      file_format: "CSV"
+      checkpoint_interval: 1000
 
     - task_name: "object"
-        file_type: "Object"
-        file_format: "CSV"
-        checkpoint_interval: 100
+      file_type: "Object"
+      file_format: "CSV"
+      checkpoint_interval: 100
 
     - task_name: "event"
-        file_type: "Event"
-        file_format: "CSV"
-        checkpoint_interval: 10000
+      file_type: "Event"
+      file_format: "CSV"
+      checkpoint_interval: 10000
 
     - task_name: "move-call"
-        file_type: "MoveCall"
-        file_format: "CSV"
-        checkpoint_interval: 1000
+      file_type: "MoveCall"
+      file_format: "CSV"
+      checkpoint_interval: 1000
 
     - task_name: "package"
-        file_type: "MovePackage"
-        file_format: "CSV"
-        checkpoint_interval: 1000
-
-    - task_name: "wrapped-object"
-        file_type: "WrappedObject"
-        file_format: "CSV"
-        checkpoint_interval: 1000
+      file_type: "MovePackage"
+      file_format: "CSV"
+      checkpoint_interval: 1000
 
     ```
 

--- a/docs/analytics-indexer.md
+++ b/docs/analytics-indexer.md
@@ -64,7 +64,7 @@ The Sui Analytics Indexer extracts, processes, and exports data from the Sui blo
     object-store: "GCS"
     bucket: "sui-mainnet-analytics"
     google-service-account: "/path/to/your/service-account.json"
-    remote_store_url: "https://checkpoints.mainnet.sui.io"
+    remote_store_url: "https://storage.googleapis.com/mysten-mainnet-checkpoints"
     package_cache_path: "/opt/sui/db/package_cache"
     tasks:
     - task_name: "checkpoint"


### PR DESCRIPTION
# Description

This PR updates the README and deployment instructions for the Sui Analytics Indexer to reflect the recent migration from CLI flags to a YAML-based configuration file. The new analytics indexer no longer supports cli flags we were using. 

Changes:

- Replaces deprecated CLI parameters (e.g., --starting-checkpoint-seq-num, --file-type, etc.) with a single analytics.yaml config.

- Introduces support for running multiple task types (ex. checkpoint, transaction, object, event, etc.) from a single config.

- Updates the systemd service setup to use the YAML path in ExecStart.
 
- Doesn't specify the starting checkpoint. Starting checkpoint automatically checks the GCS bucket for latest checkpoint processed


[Linear Ticket: (link to Linear)
](https://linear.app/szns-solutions/issue/ENG-104/update-sui-analytics-indexer-config)

## Type of change

**Please delete options that are not relevant.**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested the new changes in sui-node-test by spinning up a test VM and running the latest analytics indexer and making sure the data gets saved in GCS 
